### PR TITLE
NOJIRA felles 24 med støtte for cdi-extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 
         <!-- Felles avhengigheter i prosjektet Disse skal ALLTID være en
             RELEASE-avhengighet UNNTAK: feature-brancher og lokalt -->
-        <felles.version>2.4.0-20201030150500-a194147</felles.version>
-        <prosesstask.version>2.4.4-20201029071156-ebb43cc</prosesstask.version>
+        <felles.version>2.4.0-20201103095947-cd9cca7</felles.version>
+        <prosesstask.version>2.4.4-20201105215118-94e3e21</prosesstask.version>
         <!-- Kontrakter -->
         <fpoppdrag-kontrakt.version>2.0_20190412163011_bb51d0e</fpoppdrag-kontrakt.version>
         <fp-kontrakter.version>5.1-20200907082654-6365c08</fp-kontrakter.version>


### PR DESCRIPTION
Oppdrag hadde en rimelig fersk felles (resteasy 458) så det var bare å øke noen dager for å med med Cdi-extension for Junit5

Ting å gjøre - fortsett gjerne på denne greina (eller merge den først)
* Skrive om Databaseskjemainitialisering og JettyDevServer som for fpsak og co
* Legge til Cdi og Entityextensions
* Migrere tester til Junit5
