### PR TITLE
In memory H2 for junit testing.

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,21 +26,6 @@ jobs:
           java-version: 17
           cache: 'maven'
 
-      - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # Use commit-sha1 instead of tag for security concerns
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Hent og start Oracle image
-        id: oracle
-        run: |
-          echo "Henter og starter Oracle image"
-          cd .oracle
-          docker-compose up --quiet-pull > nohup.out 2>&1 &
-          sh -c 'tail -n +0 -f nohup.out | { sed "/Disconnected/q" && kill $$; }' || true
-
       - name: Set build version
         run: |
           echo "BUILD_VERSION=$(date +%Y.%m.%d.%H%M%S)-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV


### PR DESCRIPTION
- Virker kun for unit test kjørt fra kommandolinja og IDE
- Hver modul som bruker EntityAwareTest må ha en egen persistance.xml i main/test/resources/META-INF/
- SjekkDbStruktur må disables siden db skjema genereres automatisk av hibernate
- Flyway bør ikke kjøre heller
- Kan nok mye forbedres - har ikke tenkt så mye over dette siden dette var kun en PoC
- Lokal Jetty forventer fortsatt Oracle og vil feile om den ikke finnes.
- Man sparer ca 40 sek byggetid ved å droppe nedlasting og oppstart av oracle på GHA.