### PR TITLE
TFP-5193: Bedre exceptionhandling mot fpwsproxy

### DIFF
--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FeilDto.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FeilDto.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy;
+
+// TODO: Konsolider FeilDto fra web modul. Flytt til felles? kontrakter?
+public record FeilDto(FeilType type, String feilmelding) {
+}

--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FeilType.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FeilType.java
@@ -1,0 +1,9 @@
+package no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy;
+
+public enum FeilType {
+    MANGLER_TILGANG_FEIL,
+    TOMT_RESULTAT_FEIL,
+    OPPDRAG_FORVENTET_NEDETID,
+    GENERELL_FEIL,
+    ;
+}

--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FpWsProxySimuleringKlient.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/FpWsProxySimuleringKlient.java
@@ -1,8 +1,18 @@
 package no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy;
 
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy.FeilType.OPPDRAG_FORVENTET_NEDETID;
+import static no.nav.vedtak.mapper.json.DefaultJsonMapper.fromJson;
+
 import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.UriBuilder;
@@ -10,6 +20,8 @@ import javax.ws.rs.core.UriBuilder;
 import no.nav.foreldrepenger.kontrakter.simulering.request.OppdragskontrollDto;
 import no.nav.foreldrepenger.kontrakter.simulering.respons.BeregningDto;
 import no.nav.foreldrepenger.oppdrag.kodeverdi.YtelseType;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.exception.ManglerTilgangException;
 import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
@@ -30,12 +42,36 @@ public class FpWsProxySimuleringKlient {
         this.restConfig = RestConfig.forClient(this.getClass());
         this.endpointStartSimulering = UriBuilder.fromUri(restConfig.endpoint()).path("/simulering/start").build();
     }
-    public List<BeregningDto> utførSimulering(OppdragskontrollDto oppdragskontrollDto, YtelseType ytelseType, boolean utenInntrekk) {
-        var target = UriBuilder.fromUri(endpointStartSimulering)
-                .queryParam("uten_inntrekk", utenInntrekk);
+
+    public List<BeregningDto> utførSimuleringMedExceptionHandling(OppdragskontrollDto oppdragskontrollDto, YtelseType ytelseType, boolean utenInntrekk) {
+        var target = UriBuilder.fromUri(endpointStartSimulering).queryParam("uten_inntrekk", utenInntrekk);
         if (ytelseType != null) target.queryParam("ytelse_type", ytelseType);
         var request = RestRequest.newPOSTJson(oppdragskontrollDto, target.build(), restConfig);
-        var beregningDtos = restClient.send(request, BeregningDto[].class);
-        return Arrays.asList(beregningDtos);
+        return handleResponse(restClient.sendReturnUnhandled(request))
+                .map(r -> Arrays.asList(fromJson(r, BeregningDto[].class)))
+                .orElse(new ArrayList<>());
+    }
+
+    private static Optional<String> handleResponse(HttpResponse<String> response) {
+        int status = response.statusCode();
+        var body = response.body();
+        if (status >= HTTP_OK && status < HTTP_MULT_CHOICE) {
+            return body != null && !body.isEmpty() ? Optional.of(body) : Optional.empty();
+        } else if (status == HTTP_FORBIDDEN) {
+            throw new ManglerTilgangException("F-468816", "Mangler tilgang. Fikk http-kode 403 fra server");
+        } else {
+            if (status == HTTP_UNAVAILABLE && erDetForventetNedetid(body)) { // fpwsproxy kaster 503 feil ved nedetid av OS
+                throw new OppdragNedetidFpWsProxyException();
+            }
+            throw new IntegrasjonException("F-468817", String.format("Uventet respons %s fra FpWsProxy. Sjekk loggen til fpwsproxy for mer info.", status));
+        }
+    }
+
+    private static boolean erDetForventetNedetid(String body) {
+        try {
+            return OPPDRAG_FORVENTET_NEDETID.equals(fromJson(body, FeilDto.class).type());
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/OppdragNedetidFpWsProxyException.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/OppdragNedetidFpWsProxyException.java
@@ -1,0 +1,13 @@
+package no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy;
+
+import no.nav.vedtak.exception.IntegrasjonException;
+
+public class OppdragNedetidFpWsProxyException extends IntegrasjonException {
+
+    private static final String MELDING = "Kallet mot oppdragsystemet feilet. Feilmelding og tidspunktet tilsier at oppdragsystemet har forventet nedetid (utenfor åpningstid).";
+
+    public OppdragNedetidFpWsProxyException() {
+        super("FPO-273196", MELDING);
+    }
+
+}

--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxy.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxy.java
@@ -111,7 +111,7 @@ public class StartSimuleringTjenesteFpWsProxy {
     }
 
     private List<BeregningDto> utførSimuleringViaFpWsProxy(OppdragskontrollDto oppdragskontrollDto, YtelseType ytelseType, boolean utenInntrekk) {
-        return fpWsProxySimuleringKlient.utførSimulering(oppdragskontrollDto, ytelseType, utenInntrekk);
+        return fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(oppdragskontrollDto, ytelseType, utenInntrekk);
     }
 
     private static boolean harIkkeTomRespons(List<BeregningDto> beregningDtoListe) {

--- a/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxyTest.java
+++ b/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxyTest.java
@@ -86,7 +86,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
     public void test_skal_deaktivere_forrige_simulering_når_ny_simulering_gir_tomt_resultat() throws Exception {
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollSimulering1 = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1));
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollSimulering1));
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollSimulering1));
         simuleringTjeneste.startSimulering(oppdragskontrollSimulering1);
 
         Optional<SimuleringGrunnlag> grunnlagOpt1 = simuleringRepository.hentSimulertOppdragForBehandling(BEHANDLING_ID_2);
@@ -95,7 +95,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
 
         var oppdrag2 = lagOppdragRefusjon();
         var oppdragskontrollDtoSimulering2 = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag2));
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(null);
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(null);
         simuleringTjeneste.startSimulering(oppdragskontrollDtoSimulering2);
 
         Optional<SimuleringGrunnlag> grunnlagOpt2 = simuleringRepository.hentSimulertOppdragForBehandling(BEHANDLING_ID_2);
@@ -107,7 +107,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         OppdragskontrollDto oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1));
 
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollDto));
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollDto));
         simuleringTjeneste.startSimulering(oppdragskontrollDto);
 
         Optional<SimuleringGrunnlag> grunnlagOpt1 = simuleringRepository.hentSimulertOppdragForBehandling(BEHANDLING_ID_2);
@@ -126,7 +126,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1, oppdrag1));
         List<BeregningDto> mockRespons = lagRespons("24153532444", "423535", oppdragskontrollDto);
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(mockRespons);
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(mockRespons);
 
         // Act - Skal gi to beregningsresultater til samme mottaker
         simuleringTjeneste.startSimulering(oppdragskontrollDto);
@@ -177,13 +177,13 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         stoppnivå.beregningStoppnivaaDetaljer().add(opprettStoppnivaaDetaljer(pattern.format(fom), pattern.format(forfallsdato), PosteringType.JUST, BigDecimal.valueOf(-2786)));
 
 
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(response);
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(response);
 
         // Act
         simuleringTjeneste.startSimulering(oppdragskontrollDto);
 
         // Assert
-        verify(fpWsProxySimuleringKlient, times(2)).utførSimulering(any(), any(), anyBoolean());
+        verify(fpWsProxySimuleringKlient, times(2)).utførSimuleringMedExceptionHandling(any(), any(), anyBoolean());
 
         Optional<SimuleringGrunnlag> simuleringGrunnlag = simuleringRepository.hentSimulertOppdragForBehandling(BEHANDLING_ID_1);
         assertThat(simuleringGrunnlag).isPresent();
@@ -201,7 +201,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         // Arrange
         var oppdrag = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag));
-        when(fpWsProxySimuleringKlient.utførSimulering(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollDto));
+        when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollDto));
 
         // Act
         simuleringTjeneste.startSimulering(oppdragskontrollDto);

--- a/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/exceptions/FeilType.java
+++ b/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/exceptions/FeilType.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.oppdrag.web.app.exceptions;
 public enum FeilType {
     MANGLER_TILGANG_FEIL("MANGLER_TILGANG_FEIL"),
     TOMT_RESULTAT_FEIL("TOMT_RESULTAT_FEIL"),
+    OPPDRAG_FORVENTET_NEDETID("OPPDRAG_FORVENTET_NEDETID"),
     GENERELL_FEIL("GENERELL_FEIL");
 
     private final String navn;

--- a/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/exceptions/GeneralRestExceptionMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/exceptions/GeneralRestExceptionMapper.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import no.nav.foreldrepenger.oppdrag.OppdragNedetidException;
+import no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.fpwsproxy.OppdragNedetidFpWsProxyException;
 import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.ManglerTilgangException;
 import no.nav.vedtak.felles.jpa.TomtResultatException;
@@ -31,11 +32,22 @@ public class GeneralRestExceptionMapper implements ExceptionMapper<Throwable> {
             if (feil instanceof ManglerTilgangException) {
                 return ikkeTilgang(getExceptionMelding(feil));
             }
+            if (feil instanceof OppdragNedetidFpWsProxyException) {
+                return oppdragNedetid(getExceptionMelding(feil));
+            }
             loggTilApplikasjonslogg(feil);
             return serverError(getExceptionFullFeilmelding(feil));
         } finally {
             MDC.remove("prosess"); //$NON-NLS-1$
         }
+    }
+
+    private Response oppdragNedetid(String feilmelding) {
+        return Response
+                .status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity(new FeilDto(FeilType.OPPDRAG_FORVENTET_NEDETID, feilmelding))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     private static Response handleTomtResultatFeil(String feilmelding) {


### PR DESCRIPTION

Propagering av feil tilbake til kalleren (fpsak) med mulighet til å filtrere på om det skylder forventet nedetid av OS.