### PR TITLE
TFP-5193: Steg 2 (prodsetting), slå på interaksjon med database for nytt endepunkt

### DIFF
--- a/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxyTest.java
+++ b/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/fpwsproxy/StartSimuleringTjenesteFpWsProxyTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -53,11 +52,6 @@ import no.nav.foreldrepenger.oppdrag.oppdragslager.simulering.SimuleringMottaker
 import no.nav.foreldrepenger.oppdrag.oppdragslager.simulering.SimuleringRepository;
 import no.nav.foreldrepenger.oppdrag.oppdragslager.simulering.typer.AktørId;
 
-/** TODO:
- * Aktiver denne når {@link StartSimuleringTjenesteFpWsProxy} tar over for StartSimuleringTjeneste.
- * Nå har den bare sammenligning med direkte integrasjon aktivert, og ikke noe lagring i databasen.
- */
-@Disabled
 @ExtendWith(JpaExtension.class)
 public class StartSimuleringTjenesteFpWsProxyTest {
 

--- a/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/tjenester/simulering/SimuleringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/tjenester/simulering/SimuleringRestTjeneste.java
@@ -75,26 +75,16 @@ public class SimuleringRestTjeneste {
         return optionalSimuleringDto.orElse(null);
     }
 
-    /**
-     * NB! Dette endepunktet er under test og vil ikke lagre simuleringsgrunnlag i databasen.
-     * Denne kjøres bare etter den andre er kjørt (og det foreligger et simuleringsgrunnlag) og resultatet fra
-     * simuleringen med direkte integrasjon mot oppdragssystemet vil bli sammenlignet med det fra fp-ws-proxy!
-     * @param oppdragskontrollDto
-     * @return tom 200 respons
-     */
     @POST
     @Path("start/v2")
-    @Operation(description = "Start simulering for behandling med oppdrag via fp-ws-proxy og sammenlinger resultat med direkte integrasjon mot oppdragssystemet", summary = ("Returnerer status på om oppdrag er gyldig"), tags = "simulering")
+    @Operation(description = "Start simulering for behandling med oppdrag via fpwsproxy", summary = ("Returnerer status på om oppdrag er gyldig"), tags = "simulering")
     @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK)
-    public Response startSimuleringViaFpWsProxyFailSafe(@TilpassetAbacAttributt(supplierClass = OppdragskontrollDtoAbacSupplier.Supplier.class) @Valid OppdragskontrollDto oppdragskontrollDto) {
-        try {
-            startSimuleringTjenesteFpWsProxy.startSimulering(oppdragskontrollDto);
-        } catch (Exception e) {
-            LOG.info("Noe gikk galt med simulering av oppdrag via fp-ws-proxy", e);
-        }
+    public Response startSimuleringViaFpwsproxy(@TilpassetAbacAttributt(supplierClass = OppdragskontrollDtoAbacSupplier.Supplier.class) @Valid OppdragskontrollDto oppdragskontrollDto) {
+        startSimuleringTjenesteFpWsProxy.startSimulering(oppdragskontrollDto);
         return Response.ok().build();
     }
 
+    @Deprecated
     @POST
     @Path("start")
     @Operation(description = "Start simulering for behandling med oppdrag", summary = ("Returnerer status på om oppdrag er gyldig"), tags = "simulering")


### PR DESCRIPTION
Prodsetting av fpwsproxy endringene:
1. FPSAK: Kommenter ut kall til nytt simuleringsendepunkt i fpoppdrag (simulere via det gamle endepunktet)
2. FPOPPDRAG: Slå på lagring av simuleringsgrunnlag i DB for nytt endepunkt (via fp-ws-proxy). Da vil begge endepunktene /simulering/start og /simulering/start/v2 lagre til databasen.
3. FPSAK: Bytt kall til nytt simuleringsendepunkt (/start/v2).


Etter at det er verifisert at ting fungere som forventet, rydd opp i gammel kode:
1. FPOPPDRAG: Lag et endepunkt /start som gjør det samme som /start/v2.
2. FPSAK: Bytt til å kalle ‘/start’ endepunktet og sanner gammel kode
3. FPOPPDRAG: Sanner gammelt endepunkt (/start/v2) og tilhørende kode