### PR TITLE
TFP-5193: Steg 6, sanner endepunkt /start/v2 + opprydding

### DIFF
--- a/domenetjenester/pom.xml
+++ b/domenetjenester/pom.xml
@@ -24,8 +24,6 @@
             <artifactId>simuleringslager</artifactId>
             <scope>provided</scope>
         </dependency>
-
-
     </dependencies>
 
 </project>

--- a/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/StartSimuleringTjeneste.java
+++ b/domenetjenester/simulering/src/main/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/StartSimuleringTjeneste.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -67,8 +66,8 @@ public class StartSimuleringTjeneste {
                 System.currentTimeMillis() - t0);
 
         if (harIkkeTomRespons(simuleringResponsListe)) {
-            YtelseType ytelseType = bestemYtelseType(behandlingId, oppdragskontrollDto.oppdrag());
-            SimuleringGrunnlag simuleringGrunnlag = transformerTilDatastruktur(behandlingId, simuleringResponsListe, ytelseType);
+            var ytelseType = bestemYtelseType(behandlingId, oppdragskontrollDto.oppdrag());
+            var simuleringGrunnlag = transformerTilDatastruktur(behandlingId, simuleringResponsListe, ytelseType);
 
             utførSimuleringUtenInntrekk(oppdragskontrollDto, simuleringGrunnlag);
 
@@ -180,9 +179,9 @@ public class StartSimuleringTjeneste {
     }
 
     private void deaktiverBehandling(long behandlingId) {
-        String deaktiverForLokalTesting = Environment.current().getProperty(DEAKTIVER_SIMULERING_DEAKTIVERING);
+        var deaktiverForLokalTesting = Environment.current().getProperty(DEAKTIVER_SIMULERING_DEAKTIVERING);
         if (deaktiverForLokalTesting == null || "false".equalsIgnoreCase(deaktiverForLokalTesting)) {
-            Optional<SimuleringGrunnlag> eksisterende = simuleringRepository.hentSimulertOppdragForBehandling(behandlingId);
+            var eksisterende = simuleringRepository.hentSimulertOppdragForBehandling(behandlingId);
             eksisterende.ifPresent(grunnlag -> {
                 LOG.info("Deaktiverer simulering for behandling {}", behandlingId);
                 simuleringRepository.deaktiverSimuleringGrunnlag(grunnlag);

--- a/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/StartSimuleringTjenesteFpWsProxyTest.java
+++ b/domenetjenester/simulering/src/test/java/no/nav/foreldrepenger/oppdrag/domenetjenester/simulering/StartSimuleringTjenesteFpWsProxyTest.java
@@ -58,13 +58,12 @@ public class StartSimuleringTjenesteFpWsProxyTest {
     private static final Long BEHANDLING_ID_2 = 87890L;
     private static final String AKTØR_ID = "12345678901";
 
+    private final FpWsProxySimuleringKlient fpWsProxySimuleringKlient = mock(FpWsProxySimuleringKlient.class);
+    private final PersonTjeneste tpsTjenesteMock = mock(PersonTjeneste.class);
+    private final SimuleringResultatTransformer resultatTransformer = new SimuleringResultatTransformer(tpsTjenesteMock);
+    private final SimuleringBeregningTjeneste simuleringBeregningTjeneste = new SimuleringBeregningTjeneste();
     private SimuleringRepository simuleringRepository;
-    private FpWsProxySimuleringKlient fpWsProxySimuleringKlient = mock(FpWsProxySimuleringKlient.class);
-    private PersonTjeneste tpsTjenesteMock = mock(PersonTjeneste.class);
-    private SimuleringResultatTransformer resultatTransformer = new SimuleringResultatTransformer(tpsTjenesteMock);
-
     private StartSimuleringTjeneste simuleringTjeneste;
-    private SimuleringBeregningTjeneste simuleringBeregningTjeneste = new SimuleringBeregningTjeneste();
 
     @BeforeEach
     public void setup(EntityManager entityManager) {
@@ -74,13 +73,8 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         when(tpsTjenesteMock.hentAktørForFnr(any())).thenReturn(Optional.of(new AktørId(AKTØR_ID)));
     }
 
-
-    // TODO:
-    //  test_skalReturnereStatus200VedGyldigOppdragXml
-    //  test_skalReturnereFeilVedUgyldigOppdragXml
-
     @Test
-    public void test_skal_deaktivere_forrige_simulering_når_ny_simulering_gir_tomt_resultat() throws Exception {
+    void test_skal_deaktivere_forrige_simulering_når_ny_simulering_gir_tomt_resultat() throws Exception {
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollSimulering1 = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1));
         when(fpWsProxySimuleringKlient.utførSimuleringMedExceptionHandling(any(), any(), anyBoolean())).thenReturn(lagRespons("24153532444", "423535", oppdragskontrollSimulering1));
@@ -100,7 +94,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
     }
 
     @Test
-    public void test_skal_deaktiver_behandling_med_gitt_behandling() throws Exception {
+    void test_skal_deaktiver_behandling_med_gitt_behandling() {
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         OppdragskontrollDto oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1));
 
@@ -116,9 +110,8 @@ public class StartSimuleringTjenesteFpWsProxyTest {
         assertThat(grunnlagOpt2).isNotPresent();
     }
 
-    // TODO: Denne feiler på siste assert. Why is that? noe feil i kode eller test?
     @Test
-    public void mapperFlereBeregningsresultatTilSammeMottaker() throws Exception {
+    void mapperFlereBeregningsresultatTilSammeMottaker() {
         // Arrange
         var oppdrag1 = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag1, oppdrag1));
@@ -140,7 +133,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
     }
 
     @Test
-    public void simulerer_for_bruker_uten_inntrekk_dersom_første_resultat_gir_feilutbetaling_og_inntrekk() throws Exception {
+    void simulerer_for_bruker_uten_inntrekk_dersom_første_resultat_gir_feilutbetaling_og_inntrekk() {
         // Arrange
         DateTimeFormatter pattern = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate forfallsdato = LocalDate.now().plusMonths(1).withDayOfMonth(20);
@@ -194,7 +187,7 @@ public class StartSimuleringTjenesteFpWsProxyTest {
     }
 
     @Test
-    public void bestemmerYtelseTypeOgLagrerDetPåSimuleringsGrunnlaget() throws Exception {
+    void bestemmerYtelseTypeOgLagrerDetPåSimuleringsGrunnlaget() {
         // Arrange
         var oppdrag = lagOppdrag(130158784200L, "12345678910");
         var oppdragskontrollDto = new OppdragskontrollDto(BEHANDLING_ID_2, List.of(oppdrag));

--- a/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/tjenester/simulering/SimuleringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/oppdrag/web/app/tjenester/simulering/SimuleringRestTjeneste.java
@@ -13,9 +13,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.kontrakter.simulering.request.OppdragskontrollDto;
 import no.nav.foreldrepenger.oppdrag.domenetjenester.simulering.StartSimuleringTjeneste;
@@ -36,7 +33,6 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Consumes(MediaType.APPLICATION_JSON)
 @Transactional
 public class SimuleringRestTjeneste {
-    private static final Logger LOG = LoggerFactory.getLogger(SimuleringRestTjeneste.class);
 
     private SimuleringResultatTjeneste simuleringResultatTjeneste;
     private StartSimuleringTjeneste startSimuleringTjenesteFpWsProxy;
@@ -68,15 +64,6 @@ public class SimuleringRestTjeneste {
     public SimuleringDto hentSimuleringResultatMedOgUtenInntrekk(@Valid BehandlingIdDto behandlingIdDto) {
         Optional<SimuleringDto> optionalSimuleringDto = simuleringResultatTjeneste.hentDetaljertSimuleringsResultat(behandlingIdDto.getBehandlingId());
         return optionalSimuleringDto.orElse(null);
-    }
-
-    @Deprecated
-    @POST
-    @Path("start/v2")
-    @Operation(description = "Start simulering for behandling med oppdrag via fpwsproxy", summary = ("Returnerer status på om oppdrag er gyldig"), tags = "simulering")
-    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK)
-    public Response startSimuleringViaFpwsproxy(@TilpassetAbacAttributt(supplierClass = OppdragskontrollDtoAbacSupplier.Supplier.class) @Valid OppdragskontrollDto oppdragskontrollDto) {
-        return startSimulering(oppdragskontrollDto);
     }
 
     @POST


### PR DESCRIPTION
Prodsetting av fpwsproxy endringene:

1. FPSAK: Kommenter ut kall til nytt simuleringsendepunkt i fpoppdrag (simulere via det gamle endepunktet)
2. FPOPPDRAG: Slå på lagring av simuleringsgrunnlag i DB for nytt endepunkt (via fp-ws-proxy). Da vil begge endepunktene /simulering/start og /simulering/start/v2 lagre til databasen.
3. FPSAK: Bytt kall til nytt simuleringsendepunkt (/start/v2).
4. FPOPPDRAG: Lag et endepunkt /start som gjør det samme som /start/v2.
5. FPSAK: Bytt til å kalle ‘/start’ endepunktet og sanner gammel kode
6. FPOPPDRAG: Sanner gammelt endepunkt (/start/v2) og tilhørende kode