### PR TITLE
Legger på AD grupper som kan kreve OBO tokens fra fpoppdrag

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -12,6 +12,11 @@
   "env": {
     "APPD_ENABLED": "false"
   },
+  "groups": [
+    "27e77109-fef2-48ce-a174-269074490353",
+    "8cddda87-0a22-4d35-9186-a2c32a6ab450",
+    "f1b82579-c5b5-4617-9673-8ace5ff67f63"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -63,21 +63,25 @@ spec:
         extra:
           - "NAVident"
           - "azp_name"
+        groups:
+          {{#each groups as |group|}}
+          - id: "{{group}}"
+          {{/each}}
   {{#if AZURE_IAC_RULES}}
   accessPolicy:
-      inbound:
-        rules:
-        {{#each AZURE_IAC_RULES}}
-           - application: {{app}}
-             namespace: {{namespace}}
-             cluster: {{cluster}}
-             {{#if scopes}}
-             permissions:
-               scopes:
-               {{#each scopes}}
-                 - "{{this}}"
-               {{/each}}
-             {{/if}}
-        {{/each}}
+    inbound:
+      rules:
+      {{#each AZURE_IAC_RULES}}
+         - application: {{app}}
+           namespace: {{namespace}}
+           cluster: {{cluster}}
+           {{#if scopes}}
+           permissions:
+             scopes:
+             {{#each scopes}}
+               - "{{this}}"
+             {{/each}}
+           {{/if}}
+      {{/each}}
   {{/if}}
 

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -12,6 +12,11 @@
   "env": {
     "APPD_ENABLED": "true"
   },
+  "groups": [
+    "73107205-17ec-4a07-a56e-e0a8542f90c9",
+    "77f05833-ebfd-45fb-8be7-88eca8e7418f",
+    "0d226374-4748-4367-a38a-062dcad70034"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-TODO Simulerer utfall av økonomioppdrag for å gi mulighet til å opprette tilbakebetaling
+Foreldrepenger Vedtaksløsning (FP-OPPDRAG)
+===============
+Simulerer utfall av økonomioppdrag for å gi mulighet til å opprette tilbakebetaling
+
+### Sikkerhet
+Det er mulig å kalle tjenesten med bruk av følgende tokens
+- Azure CC
+- Azure OBO med følgende rettigheter:
+    - fpsak-saksbehandler
+    - fpsak-veileder
+    - fpsak-drift
+- STS (fases ut)

--- a/web/src/main/resources/WEB-INF/web.xml
+++ b/web/src/main/resources/WEB-INF/web.xml
@@ -6,8 +6,7 @@
 
     <!-- Listeners her slik at vi kan styre rekkefølgen de kjøres i: -->
     <listener>
-        <listener-class>no.nav.foreldrepenger.oppdrag.web.app.startupinfo.AppStartupServletContextListener
-        </listener-class>
+        <listener-class>no.nav.foreldrepenger.oppdrag.web.app.startupinfo.AppStartupServletContextListener</listener-class>
     </listener>
     <listener>
         <listener-class>no.nav.foreldrepenger.oppdrag.web.app.tjenester.ApplicationContextListener</listener-class>

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -2,12 +2,7 @@
 # OIDC/STS
 oidc.sts.well.known.url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration
 
-# SAML/STS
-securityTokenService.url=https://sts-q1.preprod.local/SecurityTokenServiceProvider/
-
 ## Klienter
-oppdrag.service.url=https://cics-q1.adeo.no/oppdrag/simulerFpServiceWSBinding
-# Eksterne (felles)
 organisasjon.rs.url=https://modapp-q1.adeo.no/ereg/api/v1/organisasjon
 
 # Database

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -2,12 +2,7 @@
 # OIDC/STS
 oidc.sts.well.known.url=https://security-token-service.nais.adeo.no/.well-known/openid-configuration
 
-# SAML/STS
-securityTokenService.url=https://sts.adeo.no/SecurityTokenServiceProvider/
-
 ## Klienter
-oppdrag.service.url=https://wasapp.adeo.no/cics/services/simulerFpServiceWSBinding
-# Eksterne (felles)
 organisasjon.rs.url=https://modapp.adeo.no/ereg/api/v1/organisasjon
 
 # Database


### PR DESCRIPTION
Enforcet endring av NAIS https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619

Per i dag er det brukere fra følgende azure grupper som får lov å kommunisere med fpoppdrag med en OBO:
- fpsak-saksbehandler
- fpsak-veileder
- fpsak-drift (swagger)