### PR TITLE
chore: Juster cpu og minne etter anbefaling / behov

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -9,11 +9,11 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "mem": "980Mi"
+    "mem": "800Mi"
   },
   "requests": {
-    "cpu": "10m",
-    "mem": "512Mi"
+    "cpu": "50m",
+    "mem": "640Mi"
   },
   "ingresses": [
     "https://fpoppdrag.dev-fss-pub.nais.io"

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -36,6 +36,7 @@ spec:
     scalingStrategy:
       cpu:
         thresholdPercentage: 80
+      scaleUpStabilizationWindowSeconds: 60
   resources:
     limits:
       memory: "{{limits.mem}}"

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -12,7 +12,7 @@
     "mem": "1000Mi"
   },
   "requests": {
-    "cpu": "50m",
+    "cpu": "100m",
     "mem": "800Mi"
   },
   "ingresses": [


### PR DESCRIPTION
Fjerner cpu-limit, og justerer cpu- og minneforespørsler til anbefalte verdier.

- Fjerner `limits.cpu` fra naiserator.yaml og JSON-filer
- Dev: cpu request=50m, mem request=640Mi, mem limit=800Mi
- Prod: cpu request=100m, mem request=800Mi, mem limit=1000Mi