### PR TITLE
TFP-7042 felles jetty server builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <sonar.projectName>fp-oppdrag</sonar.projectName>
         <sonar.projectKey>navikt_fpoppdrag</sonar.projectKey>
 
-        <felles.version>7.8.4</felles.version>
+        <felles.version>7.8.5</felles.version>
         <kontrakter.version>9.4.37</kontrakter.version>
     </properties>
 

--- a/src/main/java/no/nav/foreldrepenger/oppdrag/web/server/jetty/JettyServer.java
+++ b/src/main/java/no/nav/foreldrepenger/oppdrag/web/server/jetty/JettyServer.java
@@ -1,24 +1,5 @@
 package no.nav.foreldrepenger.oppdrag.web.server.jetty;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.eclipse.jetty.ee11.cdi.CdiDecoratingListener;
-import org.eclipse.jetty.ee11.cdi.CdiServletContainerInitializer;
-import org.eclipse.jetty.ee11.servlet.DefaultServlet;
-import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee11.servlet.ServletHolder;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.Constraint;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.ForwardedRequestCustomizer;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.ContextHandler;
-import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import no.nav.foreldrepenger.konfig.Environment;
@@ -28,12 +9,14 @@ import no.nav.foreldrepenger.oppdrag.web.app.tjenester.ServiceStarterListener;
 import no.nav.vedtak.felles.jpa.NamingStandard;
 import no.nav.vedtak.felles.jpa.flyway.FlywayUtil;
 import no.nav.vedtak.felles.jpa.jdbc.DataSourceHolder;
+import no.nav.vedtak.felles.jpa.jdbc.DatasourceUtil;
 import no.nav.vedtak.log.metrics.MetricsUtil;
+import no.nav.vedtak.server.jetty.DataSourceShutdownListener;
+import no.nav.vedtak.server.jetty.JettyServerBuilder;
 
 public class JettyServer {
 
     private static final Environment ENV = Environment.current();
-    private static final String APPLICATION = "jakarta.ws.rs.Application";
 
     private static final String CONTEXT_PATH = ENV.getProperty("context.path", "/fpoppdrag");
 
@@ -52,6 +35,7 @@ public class JettyServer {
     }
 
     void bootStrap() throws Exception {
+        MetricsUtil.init(); // Sett opp registry før andre kobler seg på
         konfigurerLogging();
         createDatasourceMigrer();
         start();
@@ -61,7 +45,7 @@ public class JettyServer {
         var jdbc = hentEllerBeregnVerdiHvisMangler("defaultDS.url", "defaultDSconfig", "jdbc_url");
         var username = hentEllerBeregnVerdiHvisMangler("defaultDS.username", "defaultDS", "username");
         var password = hentEllerBeregnVerdiHvisMangler("defaultDS.password", "defaultDS", "password");
-        var dataSource = no.nav.vedtak.felles.jpa.jdbc.DatasourceUtil.oracleDataSource(jdbc, username, password, 15);
+        var dataSource = DatasourceUtil.oracleDataSource(jdbc, username, password, 15);
         DataSourceHolder.initialize(dataSource);
         FlywayUtil.migrateLegacyOracle(dataSource, NamingStandard.DEFAULT_DS_MIGRATION_CLASSPATH);
     }
@@ -81,87 +65,19 @@ public class JettyServer {
     private static void konfigurerLogging() {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
-        MetricsUtil.scrape(); // TODO: erstatt med kommende init
     }
 
     private void start() throws Exception {
-        var server = new Server(getServerPort());
-        server.setConnectors(createConnectors(server).toArray(new Connector[]{}));
-        server.setHandler(createContext());
+        var server = JettyServerBuilder.builder()
+            .port(serverPort)
+            .contextPath(CONTEXT_PATH)
+            .withForwardedRequestCustomizer()
+            .addEventListener(new ServiceStarterListener())
+            .addEventListener(new DataSourceShutdownListener(DataSourceHolder::close))
+            .registerRestApp(InternalApiConfig.API_URI, InternalApiConfig.class)
+            .registerRestApp(ApiConfig.API_URI, ApiConfig.class)
+            .build();
         server.start();
         server.join();
     }
-
-    private List<Connector> createConnectors(Server server) {
-        List<Connector> connectors = new ArrayList<>();
-        var httpConnector = new ServerConnector(server, new HttpConnectionFactory(createHttpConfiguration()));
-        httpConnector.setPort(getServerPort());
-        connectors.add(httpConnector);
-        return connectors;
-    }
-
-    private static HttpConfiguration createHttpConfiguration() {
-        var httpConfig = new HttpConfiguration();
-        // Add support for X-Forwarded headers
-        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
-        return httpConfig;
-    }
-
-    private static ContextHandler createContext() {
-        var ctx = new ServletContextHandler(CONTEXT_PATH, ServletContextHandler.NO_SESSIONS);
-
-        // Sikkerhet
-        ctx.setSecurityHandler(simpleConstraints());
-
-        // Servlets
-        registerDefaultServlet(ctx);
-        registerServlet(ctx, 0, InternalApiConfig.API_URI, InternalApiConfig.class);
-        registerServlet(ctx, 1, ApiConfig.API_URI, ApiConfig.class);
-
-        // Starter tjenester
-        ctx.addEventListener(new ServiceStarterListener());
-
-        // Enable Weld + CDI
-        ctx.setInitParameter(CdiServletContainerInitializer.CDI_INTEGRATION_ATTRIBUTE, CdiDecoratingListener.MODE);
-        ctx.addServletContainerInitializer(new CdiServletContainerInitializer());
-        ctx.addServletContainerInitializer(new org.jboss.weld.environment.servlet.EnhancedListener());
-
-        return ctx;
-    }
-
-    private static void registerDefaultServlet(ServletContextHandler context) {
-        var defaultServlet = new ServletHolder(new DefaultServlet());
-        context.addServlet(defaultServlet, "/*");
-    }
-
-    private static void registerServlet(ServletContextHandler context, int prioritet, String path, Class<?> appClass) {
-        var servlet = new ServletHolder(new ServletContainer());
-        servlet.setName(appClass.getName());
-        servlet.setInitOrder(prioritet);
-        servlet.setInitParameter(APPLICATION, appClass.getName());
-        context.addServlet(servlet, path + "/*");
-    }
-
-    private static ConstraintSecurityHandler simpleConstraints() {
-        var handler = new ConstraintSecurityHandler();
-        // Slipp gjennom kall fra plattform til JaxRs. Foreløpig kun behov for GET
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, InternalApiConfig.API_URI + "/*"));
-        // Slipp gjennom til autentisering i JaxRs / auth-filter
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ApiConfig.API_URI + "/*"));
-        // Alt annet av paths og metoder forbudt - 403
-        handler.addConstraintMapping(pathConstraint(Constraint.FORBIDDEN, "/*"));
-        return handler;
-    }
-
-    private static ConstraintMapping pathConstraint(Constraint constraint, String path) {
-        var mapping = new ConstraintMapping();
-        mapping.setConstraint(constraint);
-        mapping.setPathSpec(path);
-        return mapping;
-    }
-
-    private Integer getServerPort() {
-        return this.serverPort;
-    }
-
 }


### PR DESCRIPTION
Adopterer felles JettyServerBuilder fra fp-felles (felles/server jetty-pakke) og oppgraderer felles til 7.8.5.

- Erstatter manuell Jetty/Connector/Context/sikkerhets-oppsett med JettyServerBuilder
- MetricsUtil.scrape() -> MetricsUtil.init() tidlig i boot (før logging/datasource), der relevant
- Legger til DataSourceShutdownListener der datasource/Flyway brukes

TFP-7042